### PR TITLE
[DON'T MERGE YET] Update addon_config.mk, remove extraneous info

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -23,6 +23,3 @@ vs:
 	# ADDON_LIBS = libs/libwebsockets/lib/vs/x64/Debug/turbojpeg-static.lib
 	# x64/Release 
 	# ADDON_LIBS = libs/libwebsockets/lib/vs/x64/Release/turbojpeg-static.lib
-
-osx:
-	ADDON_DLLS_TO_COPY = libs/turbo-jpeg/lib/osx/libturbojpeg.dylib

--- a/addon_config.mk
+++ b/addon_config.mk
@@ -6,74 +6,13 @@ meta:
 	ADDON_URL = https://github.com/robotconscience/ofxTurboJpeg
 
 common:
-	# dependencies with other addons, a list of them separated by spaces 
-	# or use += in several lines
-	ADDON_DEPENDENCIES =
-	
-	# include search paths, this will be usually parsed from the file system
-	# but if the addon or addon libraries need special search paths they can be
-	# specified here separated by spaces or one per line using +=
 	ADDON_INCLUDES = src/ 
 	ADDON_INCLUDES += libs/turbo-jpeg/include
 
-	# any special flag that should be passed to the compiler when using this
-	# addon
-	ADDON_CFLAGS = 
-	
-	# any special flag that should be passed to the linker when using this
-	# addon, also used for system libraries with -lname
-	ADDON_LDFLAGS = 
-	
-	# linux only, any library that should be included in the project using
-	# pkg-config
-	ADDON_PKG_CONFIG_LIBRARIES =
-	
-	# osx/iOS only, any framework that should be included in the project
-	ADDON_FRAMEWORKS =
-	
-	# source files, these will be usually parsed from the file system looking
-	# in the src folders in libs and the root of the addon. if your addon needs
-	# to include files in different places or a different set of files per platform
-	# they can be specified here
 	ADDON_SOURCES = src/ofxTurboJpeg.h
 	ADDON_SOURCES += src/ofxTurboJpeg.cpp
 
-	# some addons need resources to be copied to the bin/data folder of the project
-	# specify here any files that need to be copied, you can use wildcards like * and ?
-	ADDON_DATA = 
-	
-	# when parsing the file system looking for libraries exclude this for all or
-	# a specific platform
-	ADDON_LIBS_EXCLUDE =
-	
-linux64:
-	# binary libraries, these will be usually parsed from the file system but some 
-	# libraries need to passed to the linker in a specific order 
-	#nothing yet
-	
-linux:
-	#nothing yet
-	
-win_cb:
-	#nothing yet
-
 vs:
-	# source files, these will be usually parsed from the file system looking
-	# in the src folders in libs and the root of the addon. if your addon needs
-	# to include files in different places or a different set of files per platform
-	# they can be specified here
-	ADDON_SOURCES += 
-
-	# include search paths, this will be usually parsed from the file system
-	# but if the addon or addon libraries need special search paths they can be
-	# specified here separated by spaces or one per line using +=
-	ADDON_INCLUDES += 
-
-
-	# when parsing the file system looking for include paths exclude this for all or
-	# a specific platform
-	ADDON_INCLUDES_EXCLUDE
-
 	# These should get automatically set up by the projectGenerator. If you're adding
 	# to a project manually, use the following pattern:
 	# Win32/Debug
@@ -85,18 +24,5 @@ vs:
 	# x64/Release 
 	# ADDON_LIBS = libs/libwebsockets/lib/vs/x64/Release/turbojpeg-static.lib
 
-linuxarmv6l:
-	ADDON_LDFLAGS = 
-	ADDON_LIBS = 
-linuxarmv7l:
-	#nothing yet
-	
-android/armeabi:	
-	#nothing yet
-	
-android/armeabi-v7a:	
-	#nothing yet
-
 osx:
-	ADDON_DATA = libs/turbo-jpeg/lib/osx/libturbojpeg.dylib	
-	ADDON_LDFLAGS = ../../../addons/ofxTurboJpeg/libs/turbo-jpeg/lib/osx/libturbojpeg.dylib	
+	ADDON_DLLS_TO_COPY = libs/turbo-jpeg/lib/osx/libturbojpeg.dylib


### PR DESCRIPTION
Finally got the process of dylibs in addons worked out! This PR updates addon_config and removes a bunch of commented out info. Having only necessary info in the file makes it much easier to find the necessary parts, I think.

Following the merging of [this projectGenerator PR](https://github.com/openframeworks/projectGenerator/pull/92) this should be good to go.

`ADDON_DATA` wasn't actually implemented before so nothing would be copied, and it would've gone into the `bin/data/` instead of `bin/` where it needed to be, so that didn't make sense anyway.

`ADDON_LDFLAGS` would set up the dylib to be linked against, but it would still need to be manually copied into the project's `bin/data/` dir (or fail at runtime)

`ADDON_DLLS_TO_COPY` is the answer: it both sets up the project for linking this lib, _and_ copies it to `bin/`. Kind of a weird name though in the OS X context, so I'm pushing to have it renamed to something like `ADDON_DYNAMIC_LIBS`.

On Windows the libs are static, so none of this is relevant.
